### PR TITLE
HyperOS: Fix packages search

### DIFF
--- a/app/src/main/java/top/rootu/lampa/MainActivity.kt
+++ b/app/src/main/java/top/rootu/lampa/MainActivity.kt
@@ -2260,7 +2260,7 @@ class MainActivity : BaseActivity(),
     }
 
     private fun getAvailablePlayers(intent: Intent): List<ResolveInfo> {
-        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL)
             .filterNot { info ->
                 info.activityInfo.packageName.lowercase() in PLAYERS_BLACKLIST
             }


### PR DESCRIPTION
On HyperOS empty player's list witch MATCH_DEFAULT_ONLY